### PR TITLE
feat: align fetch + join code to real WFS schema

### DIFF
--- a/R/fetch_acd_zones.R
+++ b/R/fetch_acd_zones.R
@@ -1,6 +1,6 @@
 #' Fetch ACD Energieraumpläne (energy planning zones) from Vienna OGD WFS
 #'
-#' Downloads the `ogdwien:ENERGIEPLANERPOGD` layer from the Vienna Open
+#' Downloads the `ogdwien:ENERGIERAUMPLANOGD` layer from the Vienna Open
 #' Government Data WFS endpoint, caches the raw GeoJSON to `data-raw/`, and
 #' returns a valid sf object in EPSG:31287 (Austria Lambert, the working CRS).
 #'
@@ -17,8 +17,14 @@
 #' @param force Logical. When `TRUE`, ignore any existing cache file and
 #'   re-download from the WFS endpoint.
 #'
-#' @return An sf object (MULTIPOLYGON) in EPSG:31287 with all WFS attributes
-#'   intact. The attribute `snapshot_date` is set on the returned object.
+#' @return An sf object (MULTIPOLYGON) in EPSG:31287 with WFS attributes
+#'   including `OBJECTID`, `ERPLABEL`, `BEZNR`, `GEBID`, `FL_ERP`, `PLANNR`,
+#'   `BEARB_DATUM`, `WEBLINK_VO`, and `SHAPE` (geometry). The attribute
+#'   `snapshot_date` is set on the returned object.
+#'
+#' @note The real schema does **not** include `ERPTYP` or `ERPRECHTSTAT`.
+#'   Zone type and legal status must be inferred from `ERPLABEL` or
+#'   `WEBLINK_VO` — this is left as future work outside the POC scope.
 #'
 #' @export
 #'

--- a/R/fetch_buildings.R
+++ b/R/fetch_buildings.R
@@ -1,6 +1,6 @@
 #' Fetch Vienna building inventory from OGD WFS
 #'
-#' Downloads the `ogdwien:GEBAEUDEOGD` layer from the Vienna Open Government
+#' Downloads the `ogdwien:GEBAEUDEINFOOGD` layer from the Vienna Open Government
 #' Data WFS endpoint, caches the raw GeoJSON to `data-raw/`, and returns a
 #' valid sf object in EPSG:31287 (Austria Lambert, the working CRS).
 #'
@@ -19,8 +19,16 @@
 #'   can coexist in cache.
 #' @param force Logical. When `TRUE`, ignore any existing cache file.
 #'
-#' @return An sf object (MULTIPOLYGON) in EPSG:31287 with all WFS attributes.
+#' @return An sf object (MULTIPOLYGON) in EPSG:31287 with WFS attributes
+#'   including `OBJECTID`, `ACD`, `BAUJAHR`, `BEZ`, `GESCH_ANZ`, `STRNAML`,
+#'   `VONA`, `VONN`, `BISA`, `BISN`, `STRCD`, `HA_NAME`, `SHAPE` (geometry),
+#'   plus a derived `address` column composed from `STRNAML`, `VONN`, `BISN`.
 #'   The attribute `snapshot_date` is set on the returned object.
+#'
+#' @note The real schema does **not** include `HOEHE` (height) or `ADRESSE`
+#'   (address as a single field). Use `GESCH_ANZ` as a height proxy.
+#'   The `address` column is composed inline:
+#'   `paste(STRNAML, VONN, ifelse(!is.na(BISN) & BISN != VONN, paste0("-", BISN), ""))`.
 #'
 #' @export
 #'
@@ -57,6 +65,7 @@ fetch_buildings <- function(
     result <- sf::st_read(cache_path, quiet = TRUE)
     result <- sf::st_transform(result, crs = CRS_WORKING)
     result <- sf::st_make_valid(result)
+    result <- .compose_building_address(result)
     attr(result, "snapshot_date") <- snapshot_date
     return(result)
   }
@@ -115,7 +124,41 @@ fetch_buildings <- function(
   result <- sf::st_read(cache_path, quiet = TRUE)
   result <- sf::st_transform(result, crs = CRS_WORKING)
   result <- sf::st_make_valid(result)
+  result <- .compose_building_address(result)
 
   attr(result, "snapshot_date") <- snapshot_date
+  result
+}
+
+#' Compose a human-readable address column from GEBAEUDEINFOOGD street fields
+#'
+#' The WFS layer has no single `ADRESSE` field. This helper composes one from
+#' `STRNAML` (street name), `VONN` (start house number — numeric part), and
+#' optionally `BISN` (end house number for ranges). If the building has a
+#' range address (e.g., "Mariahilfer Strasse 1-7"), `BISN` is appended with
+#' a dash; otherwise only `VONN` is used.
+#'
+#' Called automatically by [fetch_buildings()] on every read path.
+#'
+#' @param result An sf data frame with columns `STRNAML`, `VONN`, `BISN`
+#'   (all may be `NA`). Missing columns are tolerated gracefully — the
+#'   resulting `address` will be `NA_character_` if all source columns are
+#'   absent or `NA`.
+#'
+#' @return `result` with an additional `address` column (character).
+#' @keywords internal
+#' @noRd
+.compose_building_address <- function(result) {
+  strnaml <- if ("STRNAML" %in% names(result)) result$STRNAML else NA_character_
+  vonn    <- if ("VONN"    %in% names(result)) result$VONN    else NA_character_
+  bisn    <- if ("BISN"    %in% names(result)) result$BISN    else NA_character_
+
+  range_suffix <- ifelse(
+    !is.na(bisn) & !is.na(vonn) & (as.character(bisn) != as.character(vonn)),
+    paste0("-", bisn),
+    ""
+  )
+
+  result$address <- trimws(paste(strnaml, vonn, range_suffix))
   result
 }

--- a/R/join_buildings_zones.R
+++ b/R/join_buildings_zones.R
@@ -4,8 +4,9 @@ NULL
 #' Spatial join of buildings to ACD zones
 #'
 #' Assigns each building to its primary ACD energy-planning zone, computes
-#' diagnostic fields (`n_overlapping_zones`, `overlap_fraction`), and
-#' classifies the relationship as a `link_status` factor.
+#' diagnostic fields (`n_overlapping_zones`, `overlap_fraction`), classifies
+#' the spatial relationship as a `link_status` factor, and cross-validates the
+#' spatial result against the city's pre-linked `ACD` field via `acd_agreement`.
 #'
 #' Both inputs must already be in EPSG:31287 (Austria Lambert). The join uses
 #' **building centroids** to determine primary zone membership, plus a
@@ -19,26 +20,75 @@ NULL
 #' 4. `straddles_boundary` — `overlap_fraction` strictly between 0.05 and 0.95
 #' 5. `in_zone` — everything else
 #'
+#' @section acd_agreement cross-validation:
+#' The Vienna city dataset carries a pre-linked `ACD` field on buildings
+#' (`ogdwien:GEBAEUDEINFOOGD`). This function cross-validates that city
+#' classification against our independent spatial join result:
+#'
+#' * `agree_in_zone` — both spatial join and city `ACD` say the building is
+#'   in a zone (the "happy path" confirming the two approaches agree)
+#' * `agree_no_zone` — both agree the building is not in a zone
+#' * `spatial_only` — spatial join says in-zone, but city `ACD` is empty/NA
+#'   (we say yes, city says no — potential under-coverage in city data)
+#' * `acd_only` — city `ACD` says in-zone, but spatial join finds no zone
+#'   (city says yes, we say no — potential stale zone geometry or data error)
+#'
+#' Disagreements (`spatial_only`, `acd_only`) are **interesting findings**,
+#' not data errors. Use [case_acd_disagreement()] to extract them.
+#'
 #' @param buildings An sf object with building footprints in EPSG:31287.
 #'   Must contain at minimum the columns returned by [fetch_buildings()]:
-#'   `OBJECTID`, `BAUJAHR`, `HOEHE`, `ADRESSE`.
+#'   `OBJECTID`, `ACD`, `BAUJAHR`, `BEZ`, `GESCH_ANZ`, `STRNAML`,
+#'   `VONA`, `VONN`, `BISA`, `BISN`, `STRCD`, `HA_NAME`, `address`.
 #' @param zones An sf object with ACD zone polygons in EPSG:31287.
-#'   Must contain at minimum: `ERPLABEL`, `ERPTYP`, `ERPRECHTSTAT`.
+#'   Must contain at minimum: `ERPLABEL`, `BEZNR`, `GEBID`, `FL_ERP`,
+#'   `PLANNR`, `BEARB_DATUM`, `WEBLINK_VO`.
 #'
-#' @return An sf object (same geometry as `buildings`) with the joined schema
-#'   defined in `STUBS.md`:
-#'   `building_id`, `building_geom`, `district`, `year_built`, `height_m`,
-#'   `address`, `zone_id`, `zone_type`, `legal_status`, `link_status`,
-#'   `n_overlapping_zones`, `overlap_fraction`.
+#' @return An sf object (same geometry as `buildings`) with columns:
+#' \describe{
+#'   \item{building_id}{`<chr>` — `OBJECTID` from buildings}
+#'   \item{geometry}{sf geometry column preserved from buildings}
+#'   \item{acd_native}{`<chr>` — pre-linked `ACD` classification from city
+#'     data; may be empty string or `NA` for buildings without a city-side
+#'     zone link}
+#'   \item{district}{`<chr>` — `BEZ` district name from buildings}
+#'   \item{year_built}{`<int>` — `BAUJAHR`}
+#'   \item{n_stories}{`<int>` — `GESCH_ANZ` (number of storeys; use as
+#'     height proxy in lieu of a height field)}
+#'   \item{address}{`<chr>` — composed from `STRNAML` / `VONN` / `BISN`
+#'     by [fetch_buildings()]}
+#'   \item{zone_id}{`<chr>` — `ERPLABEL` of primary intersecting zone,
+#'     or `NA` if none}
+#'   \item{zone_area_ha}{`<dbl>` — `FL_ERP / 10000` (zone area in hectares)}
+#'   \item{zone_district}{`<chr>` — `BEZNR` district number from zone}
+#'   \item{zone_pre_linked_gebid}{`<chr>` — `GEBID` from the zone record
+#'     (zone's own claim about which building it is associated with)}
+#'   \item{zone_legal_url}{`<chr>` — `WEBLINK_VO` URL to the legal planning
+#'     document}
+#'   \item{link_status}{`<fct>` — spatial relationship category (see
+#'     *link_status logic* section)}
+#'   \item{n_overlapping_zones}{`<int>` — number of zones whose centroid
+#'     intersects this building}
+#'   \item{overlap_fraction}{`<dbl>` — fraction of building footprint area
+#'     covered by any overlapping zone; range `[0, 1]`}
+#'   \item{acd_agreement}{`<fct>` — cross-validation result comparing our
+#'     spatial join to the city's pre-linked `ACD` field (see
+#'     *acd_agreement cross-validation* section)}
+#' }
 #'
 #' @export
 #'
+#' @seealso [acd_agreement_summary()] for a tabular cross-validation summary,
+#'   [case_acd_disagreement()] to extract disagreement rows,
+#'   [link_status_summary()] for counts by spatial relationship.
+#'
 #' @examples
 #' \dontrun{
-#' zones    <- fetch_acd_zones(max_features = 100)
+#' zones     <- fetch_acd_zones(max_features = 100)
 #' buildings <- fetch_buildings(max_features = 500)
-#' joined   <- join_buildings_zones(buildings, zones)
+#' joined    <- join_buildings_zones(buildings, zones)
 #' dplyr::count(joined, link_status)
+#' acd_agreement_summary(joined)
 #' }
 join_buildings_zones <- function(buildings, zones) {
   # ── 1. CRS guard ─────────────────────────────────────────────────────────────
@@ -60,26 +110,33 @@ join_buildings_zones <- function(buildings, zones) {
     )
   }
 
-  # ── 2. Rename / select WFS columns to canonical schema names ─────────────────
-  # NOTE: These column names are assumed from the OGD WFS schema inspection.
-  # See uncertainty note at end of file.
+  # ── 2. Rename WFS columns to canonical schema names ──────────────────────────
+  # any_of() is used throughout so the function tolerates either the canonical
+  # names (already renamed by a prior call) or the raw WFS column names.
   buildings <- buildings |>
     dplyr::rename(
-      building_id = dplyr::any_of(c("OBJECTID", "objectid")),
-      year_built  = dplyr::any_of(c("BAUJAHR", "baujahr")),
-      height_m    = dplyr::any_of(c("HOEHE", "hoehe", "GEBHOEHE", "gebhoehe")),
-      address     = dplyr::any_of(c("ADRESSE", "adresse"))
+      dplyr::any_of(c(
+        building_id = "OBJECTID",
+        acd_native  = "ACD",
+        district    = "BEZ",
+        year_built  = "BAUJAHR",
+        n_stories   = "GESCH_ANZ"
+        # address is already composed by fetch_buildings()
+      ))
     ) |>
-    # Ensure building_id is character
     dplyr::mutate(
       building_id = as.character(.data$building_id)
     )
 
   zones <- zones |>
     dplyr::rename(
-      zone_id      = dplyr::any_of(c("ERPLABEL", "erplabel")),
-      zone_type    = dplyr::any_of(c("ERPTYP", "erptyp")),
-      legal_status = dplyr::any_of(c("ERPRECHTSTAT", "erprechtstat"))
+      dplyr::any_of(c(
+        zone_id                 = "ERPLABEL",
+        zone_area_m2            = "FL_ERP",
+        zone_district           = "BEZNR",
+        zone_pre_linked_gebid   = "GEBID",
+        zone_legal_url          = "WEBLINK_VO"
+      ))
     )
 
   # ── 3. Building validity flag ─────────────────────────────────────────────────
@@ -105,12 +162,21 @@ join_buildings_zones <- function(buildings, zones) {
   zone_attrs <- zones |>
     sf::st_drop_geometry() |>
     dplyr::select(
-      dplyr::any_of(c("zone_id", "zone_type", "legal_status"))
+      dplyr::any_of(c(
+        "zone_id", "zone_area_m2", "zone_district",
+        "zone_pre_linked_gebid", "zone_legal_url"
+      ))
     )
 
-  primary_zone_id     <- zone_attrs$zone_id[primary_idx]
-  primary_zone_type   <- zone_attrs$zone_type[primary_idx]
-  primary_legal_stat  <- zone_attrs$legal_status[primary_idx]
+  primary_zone_id             <- zone_attrs$zone_id[primary_idx]
+  primary_zone_area_m2        <- if ("zone_area_m2" %in% names(zone_attrs))
+    zone_attrs$zone_area_m2[primary_idx] else rep(NA_real_, length(primary_idx))
+  primary_zone_district       <- if ("zone_district" %in% names(zone_attrs))
+    zone_attrs$zone_district[primary_idx] else rep(NA_character_, length(primary_idx))
+  primary_zone_gebid          <- if ("zone_pre_linked_gebid" %in% names(zone_attrs))
+    zone_attrs$zone_pre_linked_gebid[primary_idx] else rep(NA_character_, length(primary_idx))
+  primary_zone_legal_url      <- if ("zone_legal_url" %in% names(zone_attrs))
+    zone_attrs$zone_legal_url[primary_idx] else rep(NA_character_, length(primary_idx))
 
   # ── 8. overlap_fraction: area of footprint inside ANY overlapping zone ────────
   n_bldg          <- nrow(buildings)
@@ -157,36 +223,109 @@ join_buildings_zones <- function(buildings, zones) {
     )
   )
 
-  # ── 10. Derive district from building centroid (placeholder: NA for now) ──────
-  # Full district assignment requires the Vienna district boundary layer
-  # (BEZIRKSGRENZEOGD). For the POC this is left as NA and can be populated
-  # by a separate spatial join in a downstream target.
-  district <- NA_character_
+  # ── 10. acd_agreement cross-validation ───────────────────────────────────────
+  # Compares our spatial result to the city's pre-linked ACD field.
+  # Disagreements are analytically interesting, not data errors.
+  spatial_says_in_zone <- link_status %in%
+    c("in_zone", "straddles_boundary", "multiple_zones")
+
+  # Retrieve acd_native from the (already-renamed) buildings data frame.
+  # The column may not exist in synthetic test fixtures — default to NA.
+  acd_native_raw <- if ("acd_native" %in% names(buildings))
+    buildings$acd_native else rep(NA_character_, nrow(buildings))
+
+  acd_says_yes <- !is.na(acd_native_raw) & nzchar(trimws(as.character(acd_native_raw)))
+
+  acd_agreement <- factor(
+    dplyr::case_when(
+      spatial_says_in_zone  &  acd_says_yes  ~ "agree_in_zone",
+      !spatial_says_in_zone & !acd_says_yes  ~ "agree_no_zone",
+      spatial_says_in_zone  & !acd_says_yes  ~ "spatial_only",
+      !spatial_says_in_zone &  acd_says_yes  ~ "acd_only",
+      TRUE ~ NA_character_
+    ),
+    levels = c("agree_in_zone", "agree_no_zone", "spatial_only", "acd_only")
+  )
 
   # ── 11. Assemble output sf ────────────────────────────────────────────────────
-  # Start from buildings sf to preserve geometry and CRS
-  buildings |>
+  # Start from buildings sf to preserve geometry and CRS.
+  # district is sourced from BEZ (already renamed to district in step 2).
+  # n_stories is sourced from GESCH_ANZ (already renamed in step 2).
+  joined <- buildings |>
     dplyr::mutate(
-      building_geom       = sf::st_geometry(buildings),
-      district            = district,
-      year_built          = as.integer(.data$year_built),
-      height_m            = as.double(.data$height_m),
-      address             = as.character(.data$address),
-      zone_id             = primary_zone_id,
-      zone_type           = primary_zone_type,
-      legal_status        = primary_legal_stat,
-      link_status         = link_status,
-      n_overlapping_zones = as.integer(n_overlapping),
-      overlap_fraction    = overlap_fraction
+      year_built              = as.integer(.data$year_built),
+      n_stories               = if ("n_stories" %in% names(buildings))
+        as.integer(.data$n_stories) else NA_integer_,
+      address                 = if ("address" %in% names(buildings))
+        as.character(.data$address) else NA_character_,
+      acd_native              = as.character(acd_native_raw),
+      zone_id                 = primary_zone_id,
+      zone_area_ha            = as.double(primary_zone_area_m2) / 10000,
+      zone_district           = as.character(primary_zone_district),
+      zone_pre_linked_gebid   = as.character(primary_zone_gebid),
+      zone_legal_url          = as.character(primary_zone_legal_url),
+      link_status             = link_status,
+      n_overlapping_zones     = as.integer(n_overlapping),
+      overlap_fraction        = overlap_fraction,
+      acd_agreement           = acd_agreement
     ) |>
     dplyr::select(
       dplyr::any_of(c(
-        "building_id", "building_geom", "district",
-        "year_built", "height_m", "address",
-        "zone_id", "zone_type", "legal_status",
-        "link_status", "n_overlapping_zones", "overlap_fraction"
+        "building_id",
+        "acd_native",
+        "district",
+        "year_built",
+        "n_stories",
+        "address",
+        "zone_id",
+        "zone_area_ha",
+        "zone_district",
+        "zone_pre_linked_gebid",
+        "zone_legal_url",
+        "link_status",
+        "n_overlapping_zones",
+        "overlap_fraction",
+        "acd_agreement"
       ))
     )
+
+  joined
+}
+
+
+#' Summarise ACD cross-validation agreement
+#'
+#' Returns a one-row-per-level count of the `acd_agreement` factor from the
+#' output of [join_buildings_zones()]. Use this to understand how well the
+#' independent spatial join agrees with the city's pre-linked `ACD` field
+#' on `ogdwien:GEBAEUDEINFOOGD`.
+#'
+#' `spatial_only` rows (we say in-zone, city says no) and `acd_only` rows
+#' (city says yes, we say no) are analytically interesting disagreements —
+#' they may reveal under-coverage in the city data or stale zone geometry.
+#'
+#' @param joined Output of [join_buildings_zones()].
+#'
+#' @return A tibble with columns:
+#' \describe{
+#'   \item{acd_agreement}{`<fct>` — one of `agree_in_zone`, `agree_no_zone`,
+#'     `spatial_only`, `acd_only`}
+#'   \item{n_buildings}{`<int>` — count of buildings at this level}
+#'   \item{pct}{`<dbl>` — percentage of total buildings, rounded to 1 d.p.}
+#' }
+#'
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' joined <- join_buildings_zones(fetch_buildings(), fetch_acd_zones())
+#' acd_agreement_summary(joined)
+#' }
+acd_agreement_summary <- function(joined) {
+  joined |>
+    sf::st_drop_geometry() |>
+    dplyr::count(.data$acd_agreement, name = "n_buildings") |>
+    dplyr::mutate(pct = round(100 * .data$n_buildings / sum(.data$n_buildings), 1))
 }
 
 

--- a/R/missing_data_cases.R
+++ b/R/missing_data_cases.R
@@ -113,6 +113,29 @@ case_invalid_geometry <- function(joined) {
 }
 
 
+#' Buildings where spatial join and native ACD disagree
+#'
+#' Returns buildings where the independent spatial join result disagrees with
+#' the city's pre-linked `ACD` classification on `ogdwien:GEBAEUDEINFOOGD`.
+#' Disagreements come in two flavours:
+#'
+#' * `spatial_only` — our spatial join finds a zone, but the city's `ACD`
+#'   field is empty or `NA` (possible under-coverage in city data)
+#' * `acd_only` — the city's `ACD` field is populated, but our spatial join
+#'   finds no overlapping zone (possible stale zone geometry or data error)
+#'
+#' These rows are **analytically interesting findings**, not data errors.
+#' Investigate them before treating the city's `ACD` field as ground truth.
+#'
+#' @param joined An sf object produced by [join_buildings_zones()].
+#'
+#' @return Subset of `joined` where `acd_agreement %in% c("spatial_only", "acd_only")`.
+#' @export
+case_acd_disagreement <- function(joined) {
+  joined[joined$acd_agreement %in% c("spatial_only", "acd_only"), ]
+}
+
+
 # ── Summary tibble ───────────────────────────────────────────────────────────
 
 #' Summarise building counts by link_status

--- a/tests/testthat/test-join.R
+++ b/tests/testthat/test-join.R
@@ -8,9 +8,11 @@ test_that("join_buildings_zones produces correct link_status for all cases", {
   zone2_wkt <- "POLYGON((200050 400000, 200150 400000, 200150 400100, 200050 400100, 200050 400000))"
 
   zones <- sf::st_sf(
-    zone_id      = c("Z1", "Z2"),
-    zone_type    = c("Fernwaerme", "Waermepumpe"),
-    legal_status = c("district_heating_mandatory", "heat_pump_required"),
+    ERPLABEL    = c("Z1", "Z2"),
+    FL_ERP      = c(10000, 10000),
+    BEZNR       = c("01", "02"),
+    GEBID       = c(NA_character_, NA_character_),
+    WEBLINK_VO  = c(NA_character_, NA_character_),
     geometry     = sf::st_sfc(
       sf::st_as_sfc(zone1_wkt)[[1]],
       sf::st_as_sfc(zone2_wkt)[[1]],
@@ -61,11 +63,15 @@ test_that("join_buildings_zones produces correct link_status for all cases", {
   )))
 
   buildings <- sf::st_sf(
-    building_id = as.character(1:6),
     OBJECTID    = 1:6,
+    ACD         = c("Z1", "Z2", NA_character_, NA_character_, "Z1", NA_character_),
     BAUJAHR     = c(1990L, 2000L, 1985L, 1975L, 2010L, 1960L),
-    HOEHE       = c(10.5, 8.0, 12.3, 5.0, 9.9, 7.7),
-    ADRESSE     = paste0("Strasse ", 1:6),
+    GESCH_ANZ   = c(3L, 2L, 4L, 1L, 3L, 2L),
+    BEZ         = paste0("Bezirk ", 1:6),
+    STRNAML     = paste0("Testgasse ", 1:6),
+    VONN        = as.character(1:6),
+    BISN        = c(NA, NA, NA, NA, NA, NA),
+    address     = paste0("Testgasse ", 1:6),
     geometry    = sf::st_sfc(b1, b2, b3, b4, b5, b6, crs = 31287)
   )
 
@@ -74,9 +80,11 @@ test_that("join_buildings_zones produces correct link_status for all cases", {
 
   # ── Schema checks ─────────────────────────────────────────────────────────
   required_cols <- c(
-    "building_id", "district", "year_built", "height_m", "address",
-    "zone_id", "zone_type", "legal_status",
-    "link_status", "n_overlapping_zones", "overlap_fraction"
+    "building_id", "acd_native", "district", "year_built", "n_stories",
+    "address", "zone_id", "zone_area_ha", "zone_district",
+    "zone_pre_linked_gebid", "zone_legal_url",
+    "link_status", "n_overlapping_zones", "overlap_fraction",
+    "acd_agreement"
   )
   expect_true(
     all(required_cols %in% names(joined)),
@@ -119,10 +127,12 @@ test_that("join_buildings_zones produces correct link_status for all cases", {
 test_that("overlap_fraction is within [0, 1] for all buildings", {
   zone1_wkt <- "POLYGON((200000 400000, 200100 400000, 200100 400100, 200000 400100, 200000 400000))"
   zones <- sf::st_sf(
-    zone_id      = "Z1",
-    zone_type    = "Fernwaerme",
-    legal_status = "district_heating_mandatory",
-    geometry     = sf::st_sfc(sf::st_as_sfc(zone1_wkt)[[1]], crs = 31287)
+    ERPLABEL   = "Z1",
+    FL_ERP     = 10000,
+    BEZNR      = "01",
+    GEBID      = NA_character_,
+    WEBLINK_VO = NA_character_,
+    geometry   = sf::st_sfc(sf::st_as_sfc(zone1_wkt)[[1]], crs = 31287)
   )
 
   sq <- function(cx, cy, s = 5) {
@@ -134,15 +144,19 @@ test_that("overlap_fraction is within [0, 1] for all buildings", {
   }
 
   buildings <- sf::st_sf(
-    building_id = as.character(1:3),
-    OBJECTID    = 1:3,
-    BAUJAHR     = c(2000L, 2000L, 2000L),
-    HOEHE       = c(10.0, 10.0, 10.0),
-    ADRESSE     = c("A", "B", "C"),
-    geometry    = sf::st_sfc(
-      sq(200050, 400050),       # entirely inside
+    OBJECTID  = 1:3,
+    ACD       = c("Z1", NA_character_, NA_character_),
+    BAUJAHR   = c(2000L, 2000L, 2000L),
+    GESCH_ANZ = c(3L, 3L, 3L),
+    BEZ       = c("Bezirk 1", "Bezirk 1", "Bezirk 1"),
+    STRNAML   = c("A-Gasse", "B-Gasse", "C-Gasse"),
+    VONN      = c("1", "1", "1"),
+    BISN      = c(NA, NA, NA),
+    address   = c("A-Gasse 1", "B-Gasse 1", "C-Gasse 1"),
+    geometry  = sf::st_sfc(
+      sq(200050, 400050),         # entirely inside
       sq(199990, 400050, s = 20), # partially inside
-      sq(201000, 400050),       # entirely outside
+      sq(201000, 400050),         # entirely outside
       crs = 31287
     )
   )
@@ -159,20 +173,26 @@ test_that("overlap_fraction is within [0, 1] for all buildings", {
 test_that("CRS mismatch raises an error", {
   zone_wkt <- "POLYGON((200000 400000, 200100 400000, 200100 400100, 200000 400100, 200000 400000))"
   zones <- sf::st_sf(
-    zone_id      = "Z1",
-    zone_type    = "Fernwaerme",
-    legal_status = "district_heating_mandatory",
-    geometry     = sf::st_sfc(sf::st_as_sfc(zone_wkt)[[1]], crs = 31287)
+    ERPLABEL   = "Z1",
+    FL_ERP     = 10000,
+    BEZNR      = "01",
+    GEBID      = NA_character_,
+    WEBLINK_VO = NA_character_,
+    geometry   = sf::st_sfc(sf::st_as_sfc(zone_wkt)[[1]], crs = 31287)
   )
 
   # Buildings in wrong CRS (EPSG:4326 / WGS84)
   buildings_wgs84 <- sf::st_sf(
-    building_id = "1",
-    OBJECTID    = 1L,
-    BAUJAHR     = 2000L,
-    HOEHE       = 10.0,
-    ADRESSE     = "A",
-    geometry    = sf::st_sfc(
+    OBJECTID  = 1L,
+    ACD       = NA_character_,
+    BAUJAHR   = 2000L,
+    GESCH_ANZ = 3L,
+    BEZ       = "Bezirk 1",
+    STRNAML   = "A-Gasse",
+    VONN      = "1",
+    BISN      = NA_character_,
+    address   = "A-Gasse 1",
+    geometry  = sf::st_sfc(
       sf::st_point(c(16.37, 48.21)),
       crs = 4326
     )
@@ -190,10 +210,12 @@ test_that("find_orphan_zones returns zones with no building centroids", {
   zone2_wkt <- "POLYGON((201000 400000, 201100 400000, 201100 400100, 201000 400100, 201000 400000))"
 
   zones <- sf::st_sf(
-    zone_id      = c("Z1", "Z2"),
-    zone_type    = c("Fernwaerme", "Waermepumpe"),
-    legal_status = c("district_heating_mandatory", "heat_pump_required"),
-    geometry     = sf::st_sfc(
+    ERPLABEL   = c("Z1", "Z2"),
+    FL_ERP     = c(10000, 10000),
+    BEZNR      = c("01", "02"),
+    GEBID      = c(NA_character_, NA_character_),
+    WEBLINK_VO = c(NA_character_, NA_character_),
+    geometry   = sf::st_sfc(
       sf::st_as_sfc(zone1_wkt)[[1]],
       sf::st_as_sfc(zone2_wkt)[[1]],
       crs = 31287
@@ -202,11 +224,16 @@ test_that("find_orphan_zones returns zones with no building centroids", {
 
   # Building only in Z1, none in Z2
   buildings <- sf::st_sf(
-    OBJECTID = 1L,
-    BAUJAHR  = 2000L,
-    HOEHE    = 10.0,
-    ADRESSE  = "A",
-    geometry = sf::st_sfc(
+    OBJECTID  = 1L,
+    ACD       = NA_character_,
+    BAUJAHR   = 2000L,
+    GESCH_ANZ = 3L,
+    BEZ       = "Bezirk 1",
+    STRNAML   = "A-Gasse",
+    VONN      = "1",
+    BISN      = NA_character_,
+    address   = "A-Gasse 1",
+    geometry  = sf::st_sfc(
       sf::st_point(c(200050, 400050)),
       crs = 31287
     )
@@ -215,25 +242,32 @@ test_that("find_orphan_zones returns zones with no building centroids", {
   orphans <- find_orphan_zones(zones, buildings)
 
   expect_equal(nrow(orphans), 1L, label = "Z2 should be the sole orphan zone")
-  expect_equal(orphans$zone_id, "Z2")
+  expect_equal(orphans$ERPLABEL, "Z2")
 })
 
 
 test_that("link_status_summary returns all six levels with correct structure", {
   zone1_wkt <- "POLYGON((200000 400000, 200100 400000, 200100 400100, 200000 400100, 200000 400000))"
   zones <- sf::st_sf(
-    zone_id      = "Z1",
-    zone_type    = "Fernwaerme",
-    legal_status = "district_heating_mandatory",
-    geometry     = sf::st_sfc(sf::st_as_sfc(zone1_wkt)[[1]], crs = 31287)
+    ERPLABEL   = "Z1",
+    FL_ERP     = 10000,
+    BEZNR      = "01",
+    GEBID      = NA_character_,
+    WEBLINK_VO = NA_character_,
+    geometry   = sf::st_sfc(sf::st_as_sfc(zone1_wkt)[[1]], crs = 31287)
   )
 
   buildings <- sf::st_sf(
-    OBJECTID    = 1:2,
-    BAUJAHR     = c(2000L, 1990L),
-    HOEHE       = c(10.0, 8.0),
-    ADRESSE     = c("A", "B"),
-    geometry    = sf::st_sfc(
+    OBJECTID  = 1:2,
+    ACD       = c("Z1", NA_character_),
+    BAUJAHR   = c(2000L, 1990L),
+    GESCH_ANZ = c(3L, 2L),
+    BEZ       = c("Bezirk 1", "Bezirk 2"),
+    STRNAML   = c("A-Gasse", "B-Gasse"),
+    VONN      = c("1", "1"),
+    BISN      = c(NA, NA),
+    address   = c("A-Gasse 1", "B-Gasse 1"),
+    geometry  = sf::st_sfc(
       sf::st_polygon(list(matrix(
         c(200020, 400020, 200030, 400020, 200030, 400030, 200020, 400030, 200020, 400020),
         ncol = 2, byrow = TRUE
@@ -267,4 +301,127 @@ test_that("link_status_summary returns all six levels with correct structure", {
 
   # Colors are hex strings
   expect_true(all(grepl("^#[0-9a-fA-F]{6}$", summary$color)))
+})
+
+
+# ── acd_agreement cross-validation tests ────────────────────────────────────
+
+# Shared helper used across multiple acd_agreement tests
+.make_acd_fixtures <- function() {
+  zone_wkt <- "POLYGON((200000 400000, 200100 400000, 200100 400100, 200000 400100, 200000 400000))"
+  zones <- sf::st_sf(
+    ERPLABEL   = "Z1",
+    FL_ERP     = 10000,
+    BEZNR      = "01",
+    GEBID      = NA_character_,
+    WEBLINK_VO = NA_character_,
+    geometry   = sf::st_sfc(sf::st_as_sfc(zone_wkt)[[1]], crs = 31287)
+  )
+
+  sq <- function(cx, cy, s = 5) {
+    sf::st_polygon(list(matrix(
+      c(cx - s, cy - s, cx + s, cy - s, cx + s, cy + s,
+        cx - s, cy + s, cx - s, cy - s),
+      ncol = 2, byrow = TRUE
+    )))
+  }
+
+  # B1: spatial=in_zone,        acd_native="Z1"          → agree_in_zone
+  # B2: spatial=outside_any_zone, acd_native=NA           → agree_no_zone
+  # B3: spatial=in_zone,        acd_native=NA/""          → spatial_only
+  # B4: spatial=outside_any_zone, acd_native="Z1" (populated) → acd_only
+  buildings <- sf::st_sf(
+    OBJECTID  = 1:4,
+    ACD       = c("Z1", NA_character_, NA_character_, "Z1"),
+    BAUJAHR   = rep(2000L, 4),
+    GESCH_ANZ = rep(3L, 4),
+    BEZ       = paste0("Bezirk ", 1:4),
+    STRNAML   = paste0("Gasse ", 1:4),
+    VONN      = as.character(1:4),
+    BISN      = rep(NA_character_, 4),
+    address   = paste0("Gasse ", 1:4, " ", 1:4),
+    geometry  = sf::st_sfc(
+      sq(200050, 400050),  # B1: inside Z1
+      sq(201000, 400050),  # B2: outside Z1
+      sq(200050, 400050),  # B3: inside Z1 (same spot, different ACD)
+      sq(201000, 400050),  # B4: outside Z1 (but ACD says yes)
+      crs = 31287
+    )
+  )
+
+  list(zones = zones, buildings = buildings)
+}
+
+
+test_that("acd_agreement column exists and is a factor with 4 expected levels", {
+  f      <- .make_acd_fixtures()
+  joined <- join_buildings_zones(f$buildings, f$zones)
+
+  expect_true("acd_agreement" %in% names(joined),
+              label = "acd_agreement column must be present")
+  expect_true(is.factor(joined$acd_agreement),
+              label = "acd_agreement must be a factor")
+
+  expected_levels <- c("agree_in_zone", "agree_no_zone", "spatial_only", "acd_only")
+  expect_setequal(levels(joined$acd_agreement), expected_levels)
+})
+
+
+test_that("B1: spatial=in_zone AND acd_native populated → agree_in_zone", {
+  f      <- .make_acd_fixtures()
+  joined <- join_buildings_zones(f$buildings, f$zones)
+
+  b1 <- joined[joined$building_id == "1", ]
+  expect_equal(as.character(b1$acd_agreement), "agree_in_zone",
+               label = "B1 should be agree_in_zone")
+})
+
+
+test_that("B2: spatial=outside_any_zone AND acd_native empty/NA → agree_no_zone", {
+  f      <- .make_acd_fixtures()
+  joined <- join_buildings_zones(f$buildings, f$zones)
+
+  b2 <- joined[joined$building_id == "2", ]
+  expect_equal(as.character(b2$acd_agreement), "agree_no_zone",
+               label = "B2 should be agree_no_zone")
+})
+
+
+test_that("B3: spatial=in_zone AND acd_native empty → spatial_only", {
+  f      <- .make_acd_fixtures()
+  joined <- join_buildings_zones(f$buildings, f$zones)
+
+  b3 <- joined[joined$building_id == "3", ]
+  expect_equal(as.character(b3$acd_agreement), "spatial_only",
+               label = "B3 should be spatial_only")
+})
+
+
+test_that("B4: spatial=outside_any_zone AND acd_native populated → acd_only", {
+  f      <- .make_acd_fixtures()
+  joined <- join_buildings_zones(f$buildings, f$zones)
+
+  b4 <- joined[joined$building_id == "4", ]
+  expect_equal(as.character(b4$acd_agreement), "acd_only",
+               label = "B4 should be acd_only")
+})
+
+
+test_that("acd_agreement_summary returns 4 rows with counts summing to 100 pct", {
+  f      <- .make_acd_fixtures()
+  joined <- join_buildings_zones(f$buildings, f$zones)
+  summ   <- acd_agreement_summary(joined)
+
+  expect_true(inherits(summ, "data.frame"),
+              label = "acd_agreement_summary must return a data.frame")
+  expect_true(all(c("acd_agreement", "n_buildings", "pct") %in% names(summ)),
+              label = "expected columns missing from acd_agreement_summary")
+
+  # All 4 levels present (the fixture produces all 4)
+  expect_equal(nrow(summ), 4L,
+               label = "acd_agreement_summary should have 4 rows — one per level")
+
+  # Percentages sum to 100
+  expect_equal(sum(summ$pct), 100, tolerance = 0.1,
+               label = "pct column in acd_agreement_summary must sum to 100")
 })


### PR DESCRIPTION
Closes #1.

## Summary

- Updated rename maps in fetch and join code to match the real WFS schema verified on 2026-05-01 via DescribeFeatureType.
- Added cross-validation: the buildings layer's pre-populated \`ACD\` column is now compared against the independent spatial join, surfaced as a new \`acd_agreement\` factor in the joined output.
- Two new exports: \`acd_agreement_summary()\` and \`case_acd_disagreement()\`.

## Schema corrections

| Was assumed | Real | Fix |
|---|---|---|
| \`ENERGIEPLANERPOGD\` | \`ENERGIERAUMPLANOGD\` | snapshot.R + docs |
| \`GEBAEUDEOGD\` | \`GEBAEUDEINFOOGD\` | snapshot.R + docs |
| \`ERPTYP\`, \`ERPRECHTSTAT\` | (do not exist) | dropped |
| \`HOEHE\` | (does not exist) | use \`GESCH_ANZ\` (n_stories) |
| \`ADRESSE\` | (does not exist) | composed from \`STRNAML\` + \`VONN\` [+ \`-BISN\`] |

## Cross-validation factor

\`acd_agreement\` ∈ {\`agree_in_zone\`, \`agree_no_zone\`, \`spatial_only\`, \`acd_only\`}. Disagreements are findings, not errors — they identify cases where the city's classification and our independent spatial join differ.

## Test plan

- [x] All R files parse (\`Rscript -e parse(...)\`)
- [ ] \`devtools::test()\` once #3 (default.nix regen) lands
- [ ] \`devtools::check()\` once tests pass
- [ ] Live smoke fetch (#4)

## Verification

Parse-checked all 7 R + test files via timeout-bounded \`Rscript\`. No execution-time verification possible until #3 produces a working nix shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)