### PR TITLE
fix: building popups + empty Page 4 maps + hex-code color labels

### DIFF
--- a/docs/vignettes/articles/methodology.html
+++ b/docs/vignettes/articles/methodology.html
@@ -296,23 +296,23 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
 </figcaption>
 <div aria-describedby="tbl-tiers-caption-0ceaefa1-69ba-4598-a22c-09a6ac19f8ca">
 <div class="cell-output-display">
-<div id="uitflptipw" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
-<style>#uitflptipw table {
+<div id="trlacdayhw" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<style>#trlacdayhw table {
   font-family: system-ui, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-#uitflptipw thead, #uitflptipw tbody, #uitflptipw tfoot, #uitflptipw tr, #uitflptipw td, #uitflptipw th {
+#trlacdayhw thead, #trlacdayhw tbody, #trlacdayhw tfoot, #trlacdayhw tr, #trlacdayhw td, #trlacdayhw th {
   border-style: none;
 }
 
-#uitflptipw p {
+#trlacdayhw p {
   margin: 0;
   padding: 0;
 }
 
-#uitflptipw .gt_table {
+#trlacdayhw .gt_table {
   display: table;
   border-collapse: collapse;
   line-height: normal;
@@ -338,12 +338,12 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   border-left-color: #D3D3D3;
 }
 
-#uitflptipw .gt_caption {
+#trlacdayhw .gt_caption {
   padding-top: 4px;
   padding-bottom: 4px;
 }
 
-#uitflptipw .gt_title {
+#trlacdayhw .gt_title {
   color: #333333;
   font-size: 125%;
   font-weight: initial;
@@ -355,7 +355,7 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   border-bottom-width: 0;
 }
 
-#uitflptipw .gt_subtitle {
+#trlacdayhw .gt_subtitle {
   color: #333333;
   font-size: 85%;
   font-weight: initial;
@@ -367,7 +367,7 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   border-top-width: 0;
 }
 
-#uitflptipw .gt_heading {
+#trlacdayhw .gt_heading {
   background-color: #FFFFFF;
   text-align: center;
   border-bottom-color: #FFFFFF;
@@ -379,13 +379,13 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   border-right-color: #D3D3D3;
 }
 
-#uitflptipw .gt_bottom_border {
+#trlacdayhw .gt_bottom_border {
   border-bottom-style: solid;
   border-bottom-width: 2px;
   border-bottom-color: #D3D3D3;
 }
 
-#uitflptipw .gt_col_headings {
+#trlacdayhw .gt_col_headings {
   border-top-style: solid;
   border-top-width: 2px;
   border-top-color: #D3D3D3;
@@ -400,7 +400,7 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   border-right-color: #D3D3D3;
 }
 
-#uitflptipw .gt_col_heading {
+#trlacdayhw .gt_col_heading {
   color: #333333;
   background-color: #FFFFFF;
   font-size: 100%;
@@ -420,7 +420,7 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   overflow-x: hidden;
 }
 
-#uitflptipw .gt_column_spanner_outer {
+#trlacdayhw .gt_column_spanner_outer {
   color: #333333;
   background-color: #FFFFFF;
   font-size: 100%;
@@ -432,15 +432,15 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   padding-right: 4px;
 }
 
-#uitflptipw .gt_column_spanner_outer:first-child {
+#trlacdayhw .gt_column_spanner_outer:first-child {
   padding-left: 0;
 }
 
-#uitflptipw .gt_column_spanner_outer:last-child {
+#trlacdayhw .gt_column_spanner_outer:last-child {
   padding-right: 0;
 }
 
-#uitflptipw .gt_column_spanner {
+#trlacdayhw .gt_column_spanner {
   border-bottom-style: solid;
   border-bottom-width: 2px;
   border-bottom-color: #D3D3D3;
@@ -452,11 +452,11 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   width: 100%;
 }
 
-#uitflptipw .gt_spanner_row {
+#trlacdayhw .gt_spanner_row {
   border-bottom-style: hidden;
 }
 
-#uitflptipw .gt_group_heading {
+#trlacdayhw .gt_group_heading {
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 5px;
@@ -482,7 +482,7 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   text-align: left;
 }
 
-#uitflptipw .gt_empty_group_heading {
+#trlacdayhw .gt_empty_group_heading {
   padding: 0.5px;
   color: #333333;
   background-color: #FFFFFF;
@@ -497,15 +497,15 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   vertical-align: middle;
 }
 
-#uitflptipw .gt_from_md > :first-child {
+#trlacdayhw .gt_from_md > :first-child {
   margin-top: 0;
 }
 
-#uitflptipw .gt_from_md > :last-child {
+#trlacdayhw .gt_from_md > :last-child {
   margin-bottom: 0;
 }
 
-#uitflptipw .gt_row {
+#trlacdayhw .gt_row {
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 5px;
@@ -524,7 +524,7 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   overflow-x: hidden;
 }
 
-#uitflptipw .gt_stub {
+#trlacdayhw .gt_stub {
   color: #333333;
   background-color: #FFFFFF;
   font-size: 100%;
@@ -537,7 +537,7 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   padding-right: 5px;
 }
 
-#uitflptipw .gt_stub_row_group {
+#trlacdayhw .gt_stub_row_group {
   color: #333333;
   background-color: #FFFFFF;
   font-size: 100%;
@@ -551,15 +551,15 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   vertical-align: top;
 }
 
-#uitflptipw .gt_row_group_first td {
+#trlacdayhw .gt_row_group_first td {
   border-top-width: 2px;
 }
 
-#uitflptipw .gt_row_group_first th {
+#trlacdayhw .gt_row_group_first th {
   border-top-width: 2px;
 }
 
-#uitflptipw .gt_summary_row {
+#trlacdayhw .gt_summary_row {
   color: #333333;
   background-color: #FFFFFF;
   text-transform: inherit;
@@ -569,16 +569,16 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   padding-right: 5px;
 }
 
-#uitflptipw .gt_first_summary_row {
+#trlacdayhw .gt_first_summary_row {
   border-top-style: solid;
   border-top-color: #D3D3D3;
 }
 
-#uitflptipw .gt_first_summary_row.thick {
+#trlacdayhw .gt_first_summary_row.thick {
   border-top-width: 2px;
 }
 
-#uitflptipw .gt_last_summary_row {
+#trlacdayhw .gt_last_summary_row {
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 5px;
@@ -588,7 +588,7 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   border-bottom-color: #D3D3D3;
 }
 
-#uitflptipw .gt_grand_summary_row {
+#trlacdayhw .gt_grand_summary_row {
   color: #333333;
   background-color: #FFFFFF;
   text-transform: inherit;
@@ -598,7 +598,7 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   padding-right: 5px;
 }
 
-#uitflptipw .gt_first_grand_summary_row {
+#trlacdayhw .gt_first_grand_summary_row {
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 5px;
@@ -608,7 +608,7 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   border-top-color: #D3D3D3;
 }
 
-#uitflptipw .gt_last_grand_summary_row_top {
+#trlacdayhw .gt_last_grand_summary_row_top {
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 5px;
@@ -618,11 +618,11 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   border-bottom-color: #D3D3D3;
 }
 
-#uitflptipw .gt_striped {
+#trlacdayhw .gt_striped {
   background-color: rgba(128, 128, 128, 0.05);
 }
 
-#uitflptipw .gt_table_body {
+#trlacdayhw .gt_table_body {
   border-top-style: solid;
   border-top-width: 2px;
   border-top-color: #D3D3D3;
@@ -631,7 +631,7 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   border-bottom-color: #D3D3D3;
 }
 
-#uitflptipw .gt_footnotes {
+#trlacdayhw .gt_footnotes {
   color: #333333;
   background-color: #FFFFFF;
   border-bottom-style: none;
@@ -645,7 +645,7 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   border-right-color: #D3D3D3;
 }
 
-#uitflptipw .gt_footnote {
+#trlacdayhw .gt_footnote {
   margin: 0px;
   font-size: 90%;
   padding-top: 4px;
@@ -654,7 +654,7 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   padding-right: 5px;
 }
 
-#uitflptipw .gt_sourcenotes {
+#trlacdayhw .gt_sourcenotes {
   color: #333333;
   background-color: #FFFFFF;
   border-bottom-style: none;
@@ -668,7 +668,7 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   border-right-color: #D3D3D3;
 }
 
-#uitflptipw .gt_sourcenote {
+#trlacdayhw .gt_sourcenote {
   font-size: 90%;
   padding-top: 4px;
   padding-bottom: 4px;
@@ -676,72 +676,72 @@ Table&nbsp;1: <strong>Confidence tier distribution — <code>r format(n_building
   padding-right: 5px;
 }
 
-#uitflptipw .gt_left {
+#trlacdayhw .gt_left {
   text-align: left;
 }
 
-#uitflptipw .gt_center {
+#trlacdayhw .gt_center {
   text-align: center;
 }
 
-#uitflptipw .gt_right {
+#trlacdayhw .gt_right {
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
 
-#uitflptipw .gt_font_normal {
+#trlacdayhw .gt_font_normal {
   font-weight: normal;
 }
 
-#uitflptipw .gt_font_bold {
+#trlacdayhw .gt_font_bold {
   font-weight: bold;
 }
 
-#uitflptipw .gt_font_italic {
+#trlacdayhw .gt_font_italic {
   font-style: italic;
 }
 
-#uitflptipw .gt_super {
+#trlacdayhw .gt_super {
   font-size: 65%;
 }
 
-#uitflptipw .gt_footnote_marks {
+#trlacdayhw .gt_footnote_marks {
   font-size: 75%;
   vertical-align: 0.4em;
   position: initial;
 }
 
-#uitflptipw .gt_asterisk {
+#trlacdayhw .gt_asterisk {
   font-size: 100%;
   vertical-align: 0;
 }
 
-#uitflptipw .gt_indent_1 {
+#trlacdayhw .gt_indent_1 {
   text-indent: 5px;
 }
 
-#uitflptipw .gt_indent_2 {
+#trlacdayhw .gt_indent_2 {
   text-indent: 10px;
 }
 
-#uitflptipw .gt_indent_3 {
+#trlacdayhw .gt_indent_3 {
   text-indent: 15px;
 }
 
-#uitflptipw .gt_indent_4 {
+#trlacdayhw .gt_indent_4 {
   text-indent: 20px;
 }
 
-#uitflptipw .gt_indent_5 {
+#trlacdayhw .gt_indent_5 {
   text-indent: 25px;
 }
 
-#uitflptipw .katex-display {
+#trlacdayhw .katex-display {
   display: inline-flex !important;
   margin-bottom: 0.75em !important;
 }
 
-#uitflptipw div.Reactable > div.rt-table > div.rt-thead > div.rt-tr.rt-tr-group-header > div.rt-th-group:after {
+#trlacdayhw div.Reactable > div.rt-table > div.rt-thead > div.rt-tr.rt-tr-group-header > div.rt-th-group:after {
   height: 0px !important;
 }
 </style>
@@ -807,23 +807,23 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
 </figcaption>
 <div aria-describedby="tbl-districts-caption-0ceaefa1-69ba-4598-a22c-09a6ac19f8ca">
 <div class="cell-output-display">
-<div id="xraruiuqqk" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
-<style>#xraruiuqqk table {
+<div id="xattkqtlhd" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<style>#xattkqtlhd table {
   font-family: system-ui, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-#xraruiuqqk thead, #xraruiuqqk tbody, #xraruiuqqk tfoot, #xraruiuqqk tr, #xraruiuqqk td, #xraruiuqqk th {
+#xattkqtlhd thead, #xattkqtlhd tbody, #xattkqtlhd tfoot, #xattkqtlhd tr, #xattkqtlhd td, #xattkqtlhd th {
   border-style: none;
 }
 
-#xraruiuqqk p {
+#xattkqtlhd p {
   margin: 0;
   padding: 0;
 }
 
-#xraruiuqqk .gt_table {
+#xattkqtlhd .gt_table {
   display: table;
   border-collapse: collapse;
   line-height: normal;
@@ -849,12 +849,12 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   border-left-color: #D3D3D3;
 }
 
-#xraruiuqqk .gt_caption {
+#xattkqtlhd .gt_caption {
   padding-top: 4px;
   padding-bottom: 4px;
 }
 
-#xraruiuqqk .gt_title {
+#xattkqtlhd .gt_title {
   color: #333333;
   font-size: 125%;
   font-weight: initial;
@@ -866,7 +866,7 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   border-bottom-width: 0;
 }
 
-#xraruiuqqk .gt_subtitle {
+#xattkqtlhd .gt_subtitle {
   color: #333333;
   font-size: 85%;
   font-weight: initial;
@@ -878,7 +878,7 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   border-top-width: 0;
 }
 
-#xraruiuqqk .gt_heading {
+#xattkqtlhd .gt_heading {
   background-color: #FFFFFF;
   text-align: center;
   border-bottom-color: #FFFFFF;
@@ -890,13 +890,13 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   border-right-color: #D3D3D3;
 }
 
-#xraruiuqqk .gt_bottom_border {
+#xattkqtlhd .gt_bottom_border {
   border-bottom-style: solid;
   border-bottom-width: 2px;
   border-bottom-color: #D3D3D3;
 }
 
-#xraruiuqqk .gt_col_headings {
+#xattkqtlhd .gt_col_headings {
   border-top-style: solid;
   border-top-width: 2px;
   border-top-color: #D3D3D3;
@@ -911,7 +911,7 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   border-right-color: #D3D3D3;
 }
 
-#xraruiuqqk .gt_col_heading {
+#xattkqtlhd .gt_col_heading {
   color: #333333;
   background-color: #FFFFFF;
   font-size: 100%;
@@ -931,7 +931,7 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   overflow-x: hidden;
 }
 
-#xraruiuqqk .gt_column_spanner_outer {
+#xattkqtlhd .gt_column_spanner_outer {
   color: #333333;
   background-color: #FFFFFF;
   font-size: 100%;
@@ -943,15 +943,15 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   padding-right: 4px;
 }
 
-#xraruiuqqk .gt_column_spanner_outer:first-child {
+#xattkqtlhd .gt_column_spanner_outer:first-child {
   padding-left: 0;
 }
 
-#xraruiuqqk .gt_column_spanner_outer:last-child {
+#xattkqtlhd .gt_column_spanner_outer:last-child {
   padding-right: 0;
 }
 
-#xraruiuqqk .gt_column_spanner {
+#xattkqtlhd .gt_column_spanner {
   border-bottom-style: solid;
   border-bottom-width: 2px;
   border-bottom-color: #D3D3D3;
@@ -963,11 +963,11 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   width: 100%;
 }
 
-#xraruiuqqk .gt_spanner_row {
+#xattkqtlhd .gt_spanner_row {
   border-bottom-style: hidden;
 }
 
-#xraruiuqqk .gt_group_heading {
+#xattkqtlhd .gt_group_heading {
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 5px;
@@ -993,7 +993,7 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   text-align: left;
 }
 
-#xraruiuqqk .gt_empty_group_heading {
+#xattkqtlhd .gt_empty_group_heading {
   padding: 0.5px;
   color: #333333;
   background-color: #FFFFFF;
@@ -1008,15 +1008,15 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   vertical-align: middle;
 }
 
-#xraruiuqqk .gt_from_md > :first-child {
+#xattkqtlhd .gt_from_md > :first-child {
   margin-top: 0;
 }
 
-#xraruiuqqk .gt_from_md > :last-child {
+#xattkqtlhd .gt_from_md > :last-child {
   margin-bottom: 0;
 }
 
-#xraruiuqqk .gt_row {
+#xattkqtlhd .gt_row {
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 5px;
@@ -1035,7 +1035,7 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   overflow-x: hidden;
 }
 
-#xraruiuqqk .gt_stub {
+#xattkqtlhd .gt_stub {
   color: #333333;
   background-color: #FFFFFF;
   font-size: 100%;
@@ -1048,7 +1048,7 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   padding-right: 5px;
 }
 
-#xraruiuqqk .gt_stub_row_group {
+#xattkqtlhd .gt_stub_row_group {
   color: #333333;
   background-color: #FFFFFF;
   font-size: 100%;
@@ -1062,15 +1062,15 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   vertical-align: top;
 }
 
-#xraruiuqqk .gt_row_group_first td {
+#xattkqtlhd .gt_row_group_first td {
   border-top-width: 2px;
 }
 
-#xraruiuqqk .gt_row_group_first th {
+#xattkqtlhd .gt_row_group_first th {
   border-top-width: 2px;
 }
 
-#xraruiuqqk .gt_summary_row {
+#xattkqtlhd .gt_summary_row {
   color: #333333;
   background-color: #FFFFFF;
   text-transform: inherit;
@@ -1080,16 +1080,16 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   padding-right: 5px;
 }
 
-#xraruiuqqk .gt_first_summary_row {
+#xattkqtlhd .gt_first_summary_row {
   border-top-style: solid;
   border-top-color: #D3D3D3;
 }
 
-#xraruiuqqk .gt_first_summary_row.thick {
+#xattkqtlhd .gt_first_summary_row.thick {
   border-top-width: 2px;
 }
 
-#xraruiuqqk .gt_last_summary_row {
+#xattkqtlhd .gt_last_summary_row {
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 5px;
@@ -1099,7 +1099,7 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   border-bottom-color: #D3D3D3;
 }
 
-#xraruiuqqk .gt_grand_summary_row {
+#xattkqtlhd .gt_grand_summary_row {
   color: #333333;
   background-color: #FFFFFF;
   text-transform: inherit;
@@ -1109,7 +1109,7 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   padding-right: 5px;
 }
 
-#xraruiuqqk .gt_first_grand_summary_row {
+#xattkqtlhd .gt_first_grand_summary_row {
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 5px;
@@ -1119,7 +1119,7 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   border-top-color: #D3D3D3;
 }
 
-#xraruiuqqk .gt_last_grand_summary_row_top {
+#xattkqtlhd .gt_last_grand_summary_row_top {
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 5px;
@@ -1129,11 +1129,11 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   border-bottom-color: #D3D3D3;
 }
 
-#xraruiuqqk .gt_striped {
+#xattkqtlhd .gt_striped {
   background-color: rgba(128, 128, 128, 0.05);
 }
 
-#xraruiuqqk .gt_table_body {
+#xattkqtlhd .gt_table_body {
   border-top-style: solid;
   border-top-width: 2px;
   border-top-color: #D3D3D3;
@@ -1142,7 +1142,7 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   border-bottom-color: #D3D3D3;
 }
 
-#xraruiuqqk .gt_footnotes {
+#xattkqtlhd .gt_footnotes {
   color: #333333;
   background-color: #FFFFFF;
   border-bottom-style: none;
@@ -1156,7 +1156,7 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   border-right-color: #D3D3D3;
 }
 
-#xraruiuqqk .gt_footnote {
+#xattkqtlhd .gt_footnote {
   margin: 0px;
   font-size: 90%;
   padding-top: 4px;
@@ -1165,7 +1165,7 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   padding-right: 5px;
 }
 
-#xraruiuqqk .gt_sourcenotes {
+#xattkqtlhd .gt_sourcenotes {
   color: #333333;
   background-color: #FFFFFF;
   border-bottom-style: none;
@@ -1179,7 +1179,7 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   border-right-color: #D3D3D3;
 }
 
-#xraruiuqqk .gt_sourcenote {
+#xattkqtlhd .gt_sourcenote {
   font-size: 90%;
   padding-top: 4px;
   padding-bottom: 4px;
@@ -1187,72 +1187,72 @@ Table&nbsp;2: <strong>Per-district zone coverage — focus districts 20 (Brigitt
   padding-right: 5px;
 }
 
-#xraruiuqqk .gt_left {
+#xattkqtlhd .gt_left {
   text-align: left;
 }
 
-#xraruiuqqk .gt_center {
+#xattkqtlhd .gt_center {
   text-align: center;
 }
 
-#xraruiuqqk .gt_right {
+#xattkqtlhd .gt_right {
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
 
-#xraruiuqqk .gt_font_normal {
+#xattkqtlhd .gt_font_normal {
   font-weight: normal;
 }
 
-#xraruiuqqk .gt_font_bold {
+#xattkqtlhd .gt_font_bold {
   font-weight: bold;
 }
 
-#xraruiuqqk .gt_font_italic {
+#xattkqtlhd .gt_font_italic {
   font-style: italic;
 }
 
-#xraruiuqqk .gt_super {
+#xattkqtlhd .gt_super {
   font-size: 65%;
 }
 
-#xraruiuqqk .gt_footnote_marks {
+#xattkqtlhd .gt_footnote_marks {
   font-size: 75%;
   vertical-align: 0.4em;
   position: initial;
 }
 
-#xraruiuqqk .gt_asterisk {
+#xattkqtlhd .gt_asterisk {
   font-size: 100%;
   vertical-align: 0;
 }
 
-#xraruiuqqk .gt_indent_1 {
+#xattkqtlhd .gt_indent_1 {
   text-indent: 5px;
 }
 
-#xraruiuqqk .gt_indent_2 {
+#xattkqtlhd .gt_indent_2 {
   text-indent: 10px;
 }
 
-#xraruiuqqk .gt_indent_3 {
+#xattkqtlhd .gt_indent_3 {
   text-indent: 15px;
 }
 
-#xraruiuqqk .gt_indent_4 {
+#xattkqtlhd .gt_indent_4 {
   text-indent: 20px;
 }
 
-#xraruiuqqk .gt_indent_5 {
+#xattkqtlhd .gt_indent_5 {
   text-indent: 25px;
 }
 
-#xraruiuqqk .katex-display {
+#xattkqtlhd .katex-display {
   display: inline-flex !important;
   margin-bottom: 0.75em !important;
 }
 
-#xraruiuqqk div.Reactable > div.rt-table > div.rt-thead > div.rt-tr.rt-tr-group-header > div.rt-th-group:after {
+#xattkqtlhd div.Reactable > div.rt-table > div.rt-thead > div.rt-tr.rt-tr-group-header > div.rt-th-group:after {
   height: 0px !important;
 }
 </style>

--- a/vignettes/articles/dashboard.qmd
+++ b/vignettes/articles/dashboard.qmd
@@ -618,6 +618,15 @@ joined_for_map <- if (nrow(joined) > MAP_SAMPLE_N) {
     "</div>"
   ))
 
+  # District outlines are decorative overlays — clicks must pass THROUGH
+  # them so buildings/zones underneath retain their popups. Use label= for
+  # a hover tooltip instead of a click popup.
+  pass_through_opts <- leaflet::pathOptions(
+    interactive = FALSE,
+    pane        = "overlayPane"
+  )
+  highlight_off <- leaflet::highlightOptions(stroke = FALSE)
+
   # Non-focus districts
   m <- leaflet::addPolygons(
     m,
@@ -627,12 +636,9 @@ joined_for_map <- if (nrow(joined) > MAP_SAMPLE_N) {
     weight      = 1,
     opacity     = 0.7,
     group       = group_name,
-    popup       = ~ htmltools::HTML(paste0(
-      "<div style='color:#fff;background:#111;padding:5px;'>",
-      "<strong>Bezirk ", BEZNR, "</strong><br>",
-      NAMEG,
-      "</div>"
-    ))
+    options     = pass_through_opts,
+    highlight   = highlight_off,
+    label       = ~ paste0("Bezirk ", BEZNR, " — ", NAMEG)
   )
   # Focus districts (20 Brigittenau, 21 Floridsdorf)
   m <- leaflet::addPolygons(
@@ -643,12 +649,9 @@ joined_for_map <- if (nrow(joined) > MAP_SAMPLE_N) {
     weight      = 4,
     opacity     = 0.9,
     group       = group_name,
-    popup       = ~ htmltools::HTML(paste0(
-      "<div style='color:#fff;background:#111;padding:5px;'>",
-      "<strong>Bezirk ", BEZNR, " (focus)</strong><br>",
-      NAMEG,
-      "</div>"
-    ))
+    options     = pass_through_opts,
+    highlight   = highlight_off,
+    label       = ~ paste0("Bezirk ", BEZNR, " (focus) — ", NAMEG)
   )
   m
 }
@@ -1133,7 +1136,10 @@ if (nrow(tier_summary) > 0L) {
   tier_display <- tier_summary |>
     dplyr::mutate(
       tier_label = tier_labels[as.character(confidence_tier)],
-      tier_label = dplyr::coalesce(tier_label, as.character(confidence_tier))
+      tier_label = dplyr::coalesce(tier_label, as.character(confidence_tier)),
+      # Blank cell text — tab_style fills the cell BACKGROUND so the text
+      # would just be a redundant hex string layered on the same colour.
+      color      = ""
     ) |>
     dplyr::select(tier_label, n_buildings, pct, color)
 
@@ -1530,32 +1536,37 @@ N (this snapshot): **`r n_outside`** buildings (`r pct_outside`% of total).
 
 ```{r}
 #| label: fig-case-straddle
+#| results: asis
 
 sub_str <- case_straddle(joined, n = 50L)
 
-leaflet(data = sub_str, height = "420px") |>
-  leaflet::addProviderTiles(
-    leaflet::providers$CartoDB.DarkMatter,
-    options = leaflet::providerTileOptions(opacity = 0.95)
-  ) |>
-  leaflet::addCircleMarkers(
-    radius      = 5,
-    fillColor   = link_status_colors[["straddles_boundary"]],
-    fillOpacity = 0.85,
-    color       = "#8B4513",
-    weight      = 0.8,
-    popup       = ~ paste0(
-      "<strong>Building: </strong>", building_id, "<br>",
-      "<strong>Zone: </strong>", dplyr::coalesce(zone_id, "—"), "<br>",
-      "<strong>Overlap fraction: </strong>",
-      round(overlap_fraction, 3)
-    )
-  ) |>
-  leaflet::setView(
-    lng  = vienna_center[["lng"]],
-    lat  = vienna_center[["lat"]],
-    zoom = 12L
-  )
+if (nrow(sub_str) == 0L) {
+  cat("> **No buildings in this category in the current snapshot.** The straddling-boundary check returns 0 hits on the full Vienna data — the centroid-based join produces unambiguous assignments at this resolution. If the buffer threshold widens (e.g. 25 m), some buildings would migrate from `outside_any_zone` to a near-boundary cohort; see the **Confidence** tab for the distance-based tier breakdown.\n")
+} else {
+  print(leaflet(data = sub_str, height = "420px") |>
+    leaflet::addProviderTiles(
+      leaflet::providers$CartoDB.DarkMatter,
+      options = leaflet::providerTileOptions(opacity = 0.95)
+    ) |>
+    leaflet::addCircleMarkers(
+      radius      = 5,
+      fillColor   = link_status_colors[["straddles_boundary"]],
+      fillOpacity = 0.85,
+      color       = "#8B4513",
+      weight      = 0.8,
+      popup       = ~ paste0(
+        "<strong>Building: </strong>", building_id, "<br>",
+        "<strong>Zone: </strong>", dplyr::coalesce(zone_id, "—"), "<br>",
+        "<strong>Overlap fraction: </strong>",
+        round(overlap_fraction, 3)
+      )
+    ) |>
+    leaflet::setView(
+      lng  = vienna_center[["lng"]],
+      lat  = vienna_center[["lat"]],
+      zoom = 12L
+    ))
+}
 ```
 
 **<span class='warn'>AMBIGUOUS</span> — Building footprint spans two or more
@@ -1580,32 +1591,37 @@ Sample size (this snapshot): **`r n_straddle`** buildings
 
 ```{r}
 #| label: fig-case-multi
+#| results: asis
 
 sub_mul <- case_multi(joined, n = 50L)
 
-leaflet(data = sub_mul, height = "420px") |>
-  leaflet::addProviderTiles(
-    leaflet::providers$CartoDB.DarkMatter,
-    options = leaflet::providerTileOptions(opacity = 0.95)
-  ) |>
-  leaflet::addCircleMarkers(
-    radius      = 5,
-    fillColor   = link_status_colors[["multiple_zones"]],
-    fillOpacity = 0.85,
-    color       = "#4B0082",
-    weight      = 0.8,
-    popup       = ~ paste0(
-      "<strong>Building: </strong>", building_id, "<br>",
-      "<strong>Primary zone: </strong>",
-      dplyr::coalesce(zone_id, "—"), "<br>",
-      "<strong>N overlapping zones: </strong>", n_overlapping_zones
-    )
-  ) |>
-  leaflet::setView(
-    lng  = vienna_center[["lng"]],
-    lat  = vienna_center[["lat"]],
-    zoom = 12L
-  )
+if (nrow(sub_mul) == 0L) {
+  cat("> **No buildings in this category in the current snapshot.** The full Vienna data has 0 buildings whose centroid falls inside two or more zones simultaneously. Layered zoning would produce overlapping polygons; the current Energieraumplan publication does not. If a future snapshot introduces overlap, this tab will populate.\n")
+} else {
+  print(leaflet(data = sub_mul, height = "420px") |>
+    leaflet::addProviderTiles(
+      leaflet::providers$CartoDB.DarkMatter,
+      options = leaflet::providerTileOptions(opacity = 0.95)
+    ) |>
+    leaflet::addCircleMarkers(
+      radius      = 5,
+      fillColor   = link_status_colors[["multiple_zones"]],
+      fillOpacity = 0.85,
+      color       = "#4B0082",
+      weight      = 0.8,
+      popup       = ~ paste0(
+        "<strong>Building: </strong>", building_id, "<br>",
+        "<strong>Primary zone: </strong>",
+        dplyr::coalesce(zone_id, "—"), "<br>",
+        "<strong>N overlapping zones: </strong>", n_overlapping_zones
+      )
+    ) |>
+    leaflet::setView(
+      lng  = vienna_center[["lng"]],
+      lat  = vienna_center[["lat"]],
+      zoom = 12L
+    ))
+}
 ```
 
 **<span class='warn'>INSPECT</span> — Building centroid falls inside two or
@@ -2154,16 +2170,14 @@ if (!is.null(story_invalid) && nrow(story_invalid) > 0L) {
 
 link_summary |>
   dplyr::mutate(
-    status_label = link_status_labels[as.character(link_status)],
-    color_hex    = link_status_colors[as.character(link_status)]
+    status_label = link_status_labels[as.character(link_status)]
   ) |>
-  dplyr::select(status_label, n_buildings, pct, color_hex) |>
+  dplyr::select(status_label, n_buildings, pct) |>
   gt::gt() |>
   gt::cols_label(
     status_label = "Link status",
     n_buildings  = "N buildings",
-    pct          = "%",
-    color_hex    = "Color"
+    pct          = "%"
   ) |>
   gt::fmt_number(columns = n_buildings, decimals = 0) |>
   gt::fmt_number(columns = pct, decimals = 1) |>
@@ -2171,11 +2185,12 @@ link_summary |>
     columns = n_buildings,
     palette = c("#f7fbff", "#08306b")
   ) |>
-  gt::cols_width(color_hex ~ gt::px(60)) |>
   gt::tab_caption(
     caption = paste0(
-      "Full link-status distribution. Snapshot: ", SNAPSHOT_DATE,
-      ". Total buildings: ", n_total, "."
+      "Full link-status distribution. Colour-coded leaflets in earlier ",
+      "tabs use the same palette (in_zone green, outside grey, etc.). ",
+      "Snapshot: ", SNAPSHOT_DATE,
+      ". Total buildings: ", format(n_total, big.mark = ","), "."
     )
   )
 ```


### PR DESCRIPTION
User-reported regressions on the live dashboard:

## 1. Building popups always showed district info
**Cause:** district overlay added LAST in the leaflet pipeline → on top of markers → intercepting all clicks.
**Fix:** `pathOptions(interactive = FALSE)` on district polygons. Hover labels remain. Clicks now reach buildings.

## 2. Page 4 tabs with empty leaflets
**Cause:** full Vienna has 0 buildings in `straddles_boundary` and `multiple_zones` categories. Empty leaflets render as blank tiles.
**Fix:** empty-state guards print an explanatory blockquote pointing to the Confidence tab (where the distance-based replacement view lives).

## 3. Hex codes shown as cell text
**Cause:** `color` columns carried hex strings ("#2ca02c") as data; `tab_style` filled cell BACKGROUND but text remained on top.
**Fix:**
- Tier table (Page 3): blank the Color column data
- Link-status table (Page 6): drop the column entirely (palette already shown in leaflets)

## Verification
- 0 error markers in HTML
- Empty-state messages confirmed in rendered output
- 11 instances of `interactive=FALSE` on district overlays

Tracks #27 (empty maps); restored `docs/data/*.parquet` per #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)