### PR TITLE
Fix: panel-tabset must use fenced-div syntax to render tabs (#57 attempt 6)

### DIFF
--- a/docs/vignettes/articles/upload.html
+++ b/docs/vignettes/articles/upload.html
@@ -402,10 +402,12 @@ body.dark-mode #match-summary span[style*="dc3545"] { color: #f08080 !important;
   });
 })();
 </script>
-<section id="pages" class="level2 panel-tabset">
-<h2 class="panel-tabset anchored" data-anchor-id="pages">Pages</h2>
-<section id="upload" class="level3">
-<h3 class="anchored" data-anchor-id="upload">Upload</h3>
+<section id="pages" class="level2">
+<h2 class="anchored" data-anchor-id="pages">Pages</h2>
+<div class="tabset-margin-container"></div><div class="panel-tabset">
+<ul class="nav nav-tabs" role="tablist"><li class="nav-item" role="presentation"><a class="nav-link active" id="tabset-2-1-tab" data-bs-toggle="tab" data-bs-target="#tabset-2-1" role="tab" aria-controls="tabset-2-1" aria-selected="true" href="">Upload</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-2-2-tab" data-bs-toggle="tab" data-bs-target="#tabset-2-2" role="tab" aria-controls="tabset-2-2" aria-selected="false" href="">Methodology</a></li></ul>
+<div class="tab-content">
+<div id="tabset-2-1" class="tab-pane active" role="tabpanel" aria-labelledby="tabset-2-1-tab">
 <section id="quick-guide" class="level4 upload-page-prose">
 <h4 class="anchored" data-anchor-id="quick-guide">Quick guide</h4>
 <div data-lang="en">
@@ -637,14 +639,15 @@ body.dark-mode #match-summary span[style*="dc3545"] { color: #f08080 !important;
   </div>
 </div>
 </section>
-</section>
-<section id="methodology" class="level3">
-<h3 class="anchored" data-anchor-id="methodology">Methodology</h3>
+</div>
+<div id="tabset-2-2" class="tab-pane" role="tabpanel" aria-labelledby="tabset-2-2-tab">
 <p>The address-to-ACD lookup runs through up to 6 steps. Each tab below explains one step with a real example drawn from <code>tests/qa/ACD_TEST_V3_no_ACD_col.csv</code> and <code>inst/extdata/sample-acd-test.xlsx</code>.</p>
-<section id="steps" class="level4 panel-tabset">
-<h4 class="panel-tabset anchored" data-anchor-id="steps">Steps</h4>
-<section id="normalise-input" class="level5">
-<h5 class="anchored" data-anchor-id="normalise-input">1. Normalise input</h5>
+<section id="steps" class="level4">
+<h4 class="anchored" data-anchor-id="steps">Steps</h4>
+<div class="tabset-margin-container"></div><div class="panel-tabset">
+<ul class="nav nav-tabs" role="tablist"><li class="nav-item" role="presentation"><a class="nav-link active" id="tabset-1-1-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-1" role="tab" aria-controls="tabset-1-1" aria-selected="true" href="">1. Normalise input</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-1-2-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-2" role="tab" aria-controls="tabset-1-2" aria-selected="false" href="">2. Exact join</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-1-3-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-3" role="tab" aria-controls="tabset-1-3" aria-selected="false" href="">3. Fuzzy nearest-house</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-1-4-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-4" role="tab" aria-controls="tabset-1-4" aria-selected="false" href="">4. Composite-street splitter</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-1-5-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-5" role="tab" aria-controls="tabset-1-5" aria-selected="false" href="">5. Multi-unit dedup</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-1-6-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-6" role="tab" aria-controls="tabset-1-6" aria-selected="false" href="">6. REST API fallback</a></li></ul>
+<div class="tab-content">
+<div id="tabset-1-1" class="tab-pane active" role="tabpanel" aria-labelledby="tabset-1-1-tab">
 <p>Before any join, both the address table (ADRESSENOGD) and the user’s uploaded data are normalised the same way: whitespace is trimmed, street names are lowercased, and house numbers are lowercased and trimmed.</p>
 <p><strong>Worked example (from the V3 test file):</strong></p>
 <table class="caption-top table">
@@ -678,9 +681,8 @@ body.dark-mode #match-summary span[style*="dc3545"] { color: #f08080 !important;
 <div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb1"><pre class="sourceCode sql code-with-copy"><code class="sourceCode sql"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">LOWER</span>(<span class="fu">TRIM</span>(NAME_STR))  <span class="co">-- street_norm</span></span>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="fu">LOWER</span>(<span class="fu">TRIM</span>(NAME_ONR))  <span class="co">-- house_norm</span></span>
 <span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="fu">CAST</span>(PLZ <span class="kw">AS</span> <span class="dt">VARCHAR</span>)   <span class="co">-- plz_norm</span></span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
-</section>
-<section id="exact-join" class="level5">
-<h5 class="anchored" data-anchor-id="exact-join">2. Exact join</h5>
+</div>
+<div id="tabset-1-2" class="tab-pane" role="tabpanel" aria-labelledby="tabset-1-2-tab">
 <p>After normalisation, the tool performs a <code>LEFT JOIN</code> on <code>(plz_norm, street_norm, house_norm)</code>. When all three keys match and exactly one ACD exists for that address, <code>match_quality = "exact"</code> is returned.</p>
 <p><strong>Worked example (ObjektNr 3 from the V3 test file):</strong></p>
 <table class="caption-top table">
@@ -718,9 +720,8 @@ body.dark-mode #match-summary span[style*="dc3545"] { color: #f08080 !important;
 </tbody>
 </table>
 <p>Row ObjektNr 3 (<code>1210, Achengasse 3</code>) resolves to ACD <code>070268</code> via exact join on all three normalised keys. This is confirmed by the Quick guide example values on the Upload page.</p>
-</section>
-<section id="fuzzy-nearest-house" class="level5">
-<h5 class="anchored" data-anchor-id="fuzzy-nearest-house">3. Fuzzy nearest-house</h5>
+</div>
+<div id="tabset-1-3" class="tab-pane" role="tabpanel" aria-labelledby="tabset-1-3-tab">
 <p>When <code>(PLZ, street_norm)</code> matches but the exact house number is absent from ADRESSENOGD, the algorithm finds the registered house on the same street with the smallest numeric distance from the requested number. Distance is capped at 20 — rows further than that remain <code>unmatched</code>.</p>
 <p><strong>Worked example:</strong></p>
 <table class="caption-top table">
@@ -758,9 +759,8 @@ body.dark-mode #match-summary span[style*="dc3545"] { color: #f08080 !important;
 </tbody>
 </table>
 <p>The <code>house_distance</code> column is included in the download CSV so users can filter low-confidence results. On the 2,039-row test file, this step recovers 246 rows (12.1 percentage points lift).</p>
-</section>
-<section id="composite-street-splitter" class="level5">
-<h5 class="anchored" data-anchor-id="composite-street-splitter">4. Composite-street splitter</h5>
+</div>
+<div id="tabset-1-4" class="tab-pane" role="tabpanel" aria-labelledby="tabset-1-4-tab">
 <p>Some Vienna addresses — mainly Schrebergarten plots — use a <code>/</code> in the street field to encode two streets, e.g.&nbsp;<code>Achengasse 4/Lavantgasse 1a</code>. The splitter divides this into two sub-queries before the join, each queried independently.</p>
 <p><strong>Worked example (ObjektNr 9 from the V3 test file):</strong></p>
 <table class="caption-top table">
@@ -806,9 +806,8 @@ body.dark-mode #match-summary span[style*="dc3545"] { color: #f08080 !important;
 </tbody>
 </table>
 <p>The trailing numbers (<code>4</code> and <code>1a</code>) are extracted from each part automatically. Both ACDs are returned: the first in the <code>ACD</code> column, the second in <code>acd_b</code>. The <code>match_quality</code> is <code>split_both</code> when both parts resolve, <code>split_partial</code> when only one does.</p>
-</section>
-<section id="multi-unit-dedup" class="level5">
-<h5 class="anchored" data-anchor-id="multi-unit-dedup">5. Multi-unit dedup</h5>
+</div>
+<div id="tabset-1-5" class="tab-pane" role="tabpanel" aria-labelledby="tabset-1-5-tab">
 <p>ADRESSENOGD contains 291,823 address points but only 148,444 unique <code>(PLZ, street, house)</code> tuples. 19,319 of those tuples (13.0%) have more than one ACD — multi-unit buildings with separate staircases or sub-addresses. The lookup uses <code>GROUP BY + ARRAY_AGG(ACD ORDER BY ACD)</code> to return all ACDs for such addresses rather than picking one arbitrarily.</p>
 <p><strong>Worked example:</strong></p>
 <table class="caption-top table">
@@ -842,9 +841,8 @@ body.dark-mode #match-summary span[style*="dc3545"] { color: #f08080 !important;
 </tbody>
 </table>
 <p>The results table shows a purple <code>ambiguous_multi</code> badge with “⚠ 82 units”. The primary <code>ACD</code> column contains the lexicographically smallest ACD for backward compatibility. The “All ACDs” CSV download mode expands ambiguous rows to one row per ACD with an <code>acd_unit_index</code> column for join-back.</p>
-</section>
-<section id="rest-api-fallback" class="level5">
-<h5 class="anchored" data-anchor-id="rest-api-fallback">6. REST API fallback</h5>
+</div>
+<div id="tabset-1-6" class="tab-pane" role="tabpanel" aria-labelledby="tabset-1-6-tab">
 <p>The city’s OGDAddressService REST API (<code>GetAddressInfo</code>) can attempt server-side fuzzy matching for rows still unmatched after steps 1–5.</p>
 <p><strong>Status: NOT implemented in the DuckDB-WASM JavaScript path.</strong> The R-side implementation (<code>R/upload_algorithm.R</code>) also documents this as future work (Step 6, not implemented). The UI shows a “Try REST API” button below the results table, but clicking it sends address fragments to <code>data.wien.gv.at</code> and is a separate optional step outside the main algorithm.</p>
 <p>When/if implemented:</p>
@@ -1970,11 +1968,15 @@ document.getElementById("rest-btn").addEventListener("click", async () => {
   }
 });
 </script>
+</div>
+</div>
+</div>
+</section>
+</div>
+</div>
+</div>
 
 
-</section>
-</section>
-</section>
 </section>
 
 </main> <!-- /main -->

--- a/vignettes/articles/upload.qmd
+++ b/vignettes/articles/upload.qmd
@@ -259,7 +259,9 @@ body.dark-mode #match-summary span[style*="dc3545"] { color: #f08080 !important;
 </script>
 ```
 
-## Pages {.panel-tabset}
+## Pages
+
+::: {.panel-tabset}
 
 ### Upload
 
@@ -589,7 +591,9 @@ via [DuckDB-Wasm](https://duckdb.org/docs/api/wasm/overview.html). Es werden kei
 
 The address-to-ACD lookup runs through up to 6 steps. Each tab below explains one step with a real example drawn from `tests/qa/ACD_TEST_V3_no_ACD_col.csv` and `inst/extdata/sample-acd-test.xlsx`.
 
-#### Steps {.panel-tabset}
+#### Steps
+
+::: {.panel-tabset}
 
 ##### 1. Normalise input
 
@@ -1814,3 +1818,7 @@ document.getElementById("rest-btn").addEventListener("click", async () => {
 });
 </script>
 ```
+
+:::
+
+:::


### PR DESCRIPTION
Attempt #6 of #57. Closes #57.

## What was wrong

PR #60 merged but the panel-tabset tabs did not render. Live upload.html had 0 nav-tabs and 0 role=tab elements — one flat scroll instead of clickable tabs.

Root cause: heading-attribute syntax `## Pages {.panel-tabset}` silently failed; the class went onto the H2 element but Quarto did not generate the tab UI wrapper.

## What this fixes

Converts both panel-tabsets to fenced-div syntax (`::: {.panel-tabset}`) which is the pattern that works elsewhere on the site (upload-internals.qmd uses it for Fix A/B/C/D tabs).

## Verification (local render, before push)

| Gate | Expected | Actual |
|---|---|---|
| nav-tabs count | >= 2 | 2 |
| role=tab count | >= 8 | 8 |
| tab-pane count | >= 8 | 8 |
| Upload tab label | >= 1 | 1 |
| Methodology tab label | >= 1 | 1 |
| Performance leak | 0 | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)